### PR TITLE
Escape doublequotes in lint script for Windows compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "clean": "rimraf coverage build tmp",
     "build": "tsc -p tsconfig.release.json",
     "watch": "tsc -w -p tsconfig.release.json",
-    "lint": "tslint -t stylish --type-check --project 'tsconfig.json'",
+    "lint": "tslint -t stylish --type-check --project \"tsconfig.json\"",
     "pretest": "npm run lint",
     "test": "npm run test-only",
     "test-only": "jest --coverage",


### PR DESCRIPTION
Fixes https://github.com/jsynowiec/node-typescript-boilerplate/issues/5