### PR TITLE
Remove engineStrict attribute from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "node-typescript-boilerplate",
   "version": "0.0.0",
   "description": "Minimalistic boilerplate to quick-start Node.js development in TypeScript.",
-  "engineStrict": true,
   "engines": {
     "node": ">= 10.13 <11"
   },


### PR DESCRIPTION
Remove engineStrict attribute from package.json, because [it is no longer used](https://docs.npmjs.com/files/package.json.html#enginestrict).
