### PR TITLE
Add Volta

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,19 +7,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [12.x]
-
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
+    - uses: volta-cli/action@v1
+    - run: npm ci --no-audit
     - run: npm run lint --if-present
-    - run: npm run build --if-present
     - run: npm test
+    - run: npm run build --if-present
       env:
         CI: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,22 @@
-language: node_js
-node_js:
-  - "12"
-  - "node"
+dist: bionic
+
+cache:
+  npm: true
+  directories:
+    - /home/travis/.volta
+
+env:
+  - CI=true
+
+before_install:
+  - curl https://get.volta.sh | bash
+  - export VOLTA_HOME=$HOME/.volta
+  - export PATH=$VOLTA_HOME:$PATH
+
+install:
+  - npm ci --no-audit
+
+script:
+  - npm run lint --if-present
+  - npm run test
+  - npm run build --if-present

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
+[![Sponsor][sponsor-badge]][sponsor]
 [![TypeScript version][ts-badge]][typescript-39]
 [![Node.js version][nodejs-badge]][nodejs]
 [![APLv2][license-badge]][LICENSE]
 [![Build Status - Travis][travis-badge]][travis-ci]
 [![Build Status - GitHub Actions][gha-badge]][gha-ci]
-[![Sponsor][sponsor-badge]][sponsor]
 
 # node-typescript-boilerplate
 
@@ -17,9 +17,10 @@
 + Type definitions for Node.js and Jest
 + [Prettier][prettier] to enforce consistent code style
 + NPM [scripts](#available-scripts) for common operations
-+ simple example of TypeScript code and unit test
++ Simple example of TypeScript code and unit test
 + .editorconfig for consistent file format
-+ example configuration for [GitHub Actions][gh-actions] and [Travis CI][travis]
++ Reproducible environments thanks to [Volta][volta]
++ Example configuration for [GitHub Actions][gh-actions] and [Travis CI][travis]
 
 🤲 Free as in speech: available under the APLv2 license.
 
@@ -61,6 +62,12 @@ unzip node-typescript-boilerplate.zip && rm node-typescript-boilerplate.zip
 
 ## Additional Informations
 
+### Why include Volta
+
+[Volta][volta]’s toolchain always keeps track of where you are, it makes sure the tools you use always respect the settings of the project you’re working on. This means you don’t have to worry about changing the state of your installed software when switching between projects. For example, it's [used by engineers at LinkedIn][volta-tomdale] to standarize tools and have reproducible development environments.
+
+I recommend to [install][volta-getting-started] Volta and use it to manage your project's toolchain.
+
 ### Writing tests in JavaScript
 
 Writing unit tests in TypeScript can sometimes be troublesome and confusing. Especially when mocking dependencies and using spies.
@@ -69,7 +76,7 @@ This is **optional**, but if you want to learn how to write JavaScript tests for
 
 ## Backers & Sponsors
 
-Support this project by becoming a sponsor.
+Support this project by becoming a [sponsor][sponsor].
 
 ## License
 Licensed under the APLv2. See the [LICENSE](https://github.com/jsynowiec/node-typescript-boilerplate/blob/master/LICENSE) file for details.
@@ -93,6 +100,10 @@ Licensed under the APLv2. See the [LICENSE](https://github.com/jsynowiec/node-ty
 [eslint]: https://github.com/eslint/eslint
 [wiki-js-tests]: https://github.com/jsynowiec/node-typescript-boilerplate/wiki/Unit-tests-in-plain-JavaScript
 [prettier]: https://prettier.io
+[volta]: https://volta.sh
+[volta-getting-started]: https://docs.volta.sh/guide/getting-started
+[volta-tomdale]: https://twitter.com/tomdale/status/1162017336699838467?s=20
+
 [gh-actions]: https://github.com/features/actions
 [travis]: https://travis-ci.org
 

--- a/package.json
+++ b/package.json
@@ -32,5 +32,9 @@
   "license": "Apache-2.0",
   "dependencies": {
     "tslib": "~2.0.0"
+  },
+  "volta": {
+    "node": "12.18.2",
+    "npm": "6.14.5"
   }
 }


### PR DESCRIPTION
Recommend using [Volta](https://volta.sh) to manage project's toolchain:

- explain in README why it's beneficial to use Volta,
- pin Node.js and NPM versions,
- update TravisCI and GitHub Actions configs to use Volta,