### PR TITLE
rootDir points to ./src

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "node16",
     "lib": ["ES2022"],
     "moduleResolution": "node16",
-    "rootDir": ".",
+    "rootDir": "src/",
     "outDir": "build",
     "allowSyntheticDefaultImports": true,
     "importHelpers": true,


### PR DESCRIPTION
with the new typescript update, when you build the src folder, the src folder itself will also be added into the build folder. This commit fixes that