### PR TITLE
Update github workflow actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: actions/checkout@v4
+      - uses: volta-cli/action@v4
       - run: npm ci --no-audit
       - run: npm run lint --if-present
       - run: npm test


### PR DESCRIPTION
Fix build warnings

> Node.js 16 actions are deprecated